### PR TITLE
feat: add configurable keybind, default toggle state, and improve UX

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 James Roll
+Copyright (c) 2021 Kerminal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ This is a utility for FiveM that allows the live editing of vehicle handling and
 - Download the GitHub repository code.
 - Add to the `resources` folder.
 - Ensure `vehicleDebug` in the server.cfg, or `ensure vehicleDebug` in <kbd>F8</kbd>.
-- Open <kbd>F8</kbd> and run the command `vehdebug` to toggle the UI on.
-- Press <kbd>LALT</kbd> to open the handling editor.
+- Press <kbd>Right Alt</kbd> to open the handling editor while in a vehicle (configurable in `cl_config.lua`).
+- Use the command `vehdebug` to toggle the debugger on/off if needed.
 - Enjoy!
 
+**Note:** The `vehdebug` command is unrestricted by default. If you're running this in a live environment, you may want to modify the command registration in `cl_debugger.lua` (line 264) to change `false` to `true` to restrict it to ACE permitted individuals only or modify the code how you see fit for you. You can also set `EnabledByDefault = false` in `cl_config.lua` to have the debugger disabled by default.
+
 ## Editor
-Press Left Alt while in a vehicle to bring up the menu, or change the key under the FiveM keybind settings. Click the input boxes for whichever value you would like to modify, and change it. That's it! The handling will immediately update as you type. Hover over the fields for a little more information on what that particular field does.
+Press Right Alt (default) while in a vehicle to bring up the menu. You can change the keybind in `cl_config.lua` - see the [FiveM keybind reference](https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/) for available key names. Click the input boxes for whichever value you would like to modify, and change it. That's it! The handling will immediately update as you type. Hover over the fields for a little more information on what that particular field does.
 
 You can save the handling by clicking "Copy Handling" near the top. You will need to paste that over the handling file for the vehicle. Make sure you're replacing everything from **mass** to **monetary value**, nothing more, and nothing less.
 
@@ -23,6 +25,15 @@ In the top-middle of the screen, there are numbers to represent some "tops" for 
 * Top deceleration - An arbitrary value to represent how quickly the vehicle has decelerated.
 
 ![LiveHandling2](https://user-images.githubusercontent.com/8594390/113525004-6e12a400-9580-11eb-8ad2-a5fd70aef41d.png)
+
+---
+
+### 🎮 Join ProductionRP - An Allowlisted FiveM Roleplay Server
+Experience high-quality roleplay at **[ProductionRP.org](https://ProductionRP.org)**
+
+![ProductionRP](https://i.gyazo.com/947c5cdb1dbb9d47322262745d85f864.gif)
+
+---
 
 ## Credits
 Thanks to the post by V4D3R on 5Mods for describing the handling fields a little more:

--- a/cl_config.lua
+++ b/cl_config.lua
@@ -1,5 +1,7 @@
 Config = {
-	Precision = 10000.0,
+	Precision = 100.0,
+	Keybind = "rmenu", -- lmenu = Left Alt, rmenu = Right Alt | Full list: https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/
+	EnabledByDefault = true, -- Set to false if you want the debugger disabled by default (use /vehdebug to enable)
 	Fields = {
 		{ name = "fMass", type = "float", description = [[
 			The weight of the vehicle. Values should be given in Kilograms.
@@ -31,7 +33,15 @@ Config = {
 				<li>Z: -10.0 to 10.0. Positive values move the center of gravity upwards.</li>
 			</ul>
 		]] },
-		{ name = "vecInertiaMultiplier", type = "vector" },
+		{ name = "vecInertiaMultiplier", type = "vector", description = [[
+			Handles the vehicle's inertia.<br>
+			Values (Default values tend to be 1.0):
+			<ul>
+				<li>X: -10.0 to 10.0. Positive values increase Pitch (Forward & Back).</li>
+				<li>Y: -10.0 to 10.0. Positive values increase Roll (Side to Side).</li>
+				<li>Z: -10.0 to 10.0. Positive values increase Yaw (Rotation).</li>
+			</ul>
+		]] },
 		{ name = "fDriveBiasFront", type = "float", description = [[
 			This is used to determine whether a vehicle is front, rear, or four wheel drive.<br>Values:
 			<ul>
@@ -117,13 +127,17 @@ Config = {
 			</ul>
 		]] },
 		{ name = "fTractionCurveMax", type = "float", description = [[
-			Cornering grip of the vehicle as a multiplier of the tire surface friction.
+			Cornering grip of the vehicle as a multiplier of the tire surface friction.<br>
+			ie: Higher value gives better grip while off pedal
 		]] },
 		{ name = "fTractionCurveMin", type = "float", description = [[
-			Accelerating/braking grip of the vehicle as a multiplier of the tire surface friction.
+			Accelerating/braking grip of the vehicle as a multiplier of the tire surface friction.<br>
+			ie: Higher value gives better grip while on pedal
 		]] },
 		{ name = "fTractionCurveLateral", type = "float", description = [[
-			Shape of lateral traction curve.
+			Shape of lateral traction curve (peak traction position in degrees sideways = fTractionCurveLateral / 2).<br>
+			Lower values make the vehicle's grip more responsive but less forgiving to loss of traction.<br>
+			Higher values make the vehicle's grip less responsive but more forgiving to loss of traction. Also known as "slip angle".
 		]] },
 		{ name = "fTractionSpringDeltaMax", type = "float", description = [[
 			This value determines at what distance above the ground the car will lose traction.
@@ -207,10 +221,11 @@ Config = {
 			</ul>
 		]] },
 		{ name = "fRollCentreHeightRear", type = "float", description = [[
-			This value modify the weight transmission during an acceleration between the front and rear. high positive value can make your car able to do wheelies.<br>
+			This value modify the weight transmitted during an acceleration between the front and rear.<br>
+			High positive value can make your car able to do wheelies.<br>
 			Values (Recommended -0.15 to 0.15):
 			<ul>
-				<li>Larger Numbers = less rollovers.</li>
+				<li>Larger Numbers = less acceleration/deceleration sway.</li>
 			</ul>
 		]] },
 		{ name = "fCollisionDamageMult", type = "float", description = [[

--- a/cl_debugger.lua
+++ b/cl_debugger.lua
@@ -3,7 +3,8 @@ Debugger = {
 	speed = 0.0,
 	accel = 0.0,
 	decel = 0.0,
-	toggle = false
+	toggle = false,
+	toggleOn = Config.EnabledByDefault
 }
 
 --[[ Functions ]]--
@@ -198,10 +199,13 @@ function Debugger:Focus(toggle)
 end
 
 function Debugger:ToggleOn(toggleData)
-	-- if toggle and not DoesEntityExist(self.vehicle or 0) then return end
-
-	self.toggle = toggleData
+	self.toggleOn = toggleData
 	self:Invoke("toggle", toggleData)
+	
+	-- Close the UI if we're disabling
+	if not toggleData and self.hasFocus then
+		self:Focus(false)
+	end
 end
 
 function Debugger:Invoke(_type, data)
@@ -249,15 +253,20 @@ RegisterNUICallback("resetStats", function(data, cb)
 	Debugger:ResetStats()
 end)
 
---[[ Commands ]]--
+--[[ Commands ]]
 RegisterCommand("+vehicleDebug", function()
 	if Debugger.toggleOn == false then return end
 	Debugger:Focus(not Debugger.hasFocus)
 end, true)
 
-RegisterKeyMapping("+vehicleDebug", "Vehicle Debugger", "keyboard", "lmenu")
+RegisterKeyMapping("+vehicleDebug", "Vehicle Debugger", "keyboard", Config.Keybind)
 
 RegisterCommand("vehdebug", function()
-	Debugger:ToggleOn(not Debugger.toggleOn)
 	Debugger.toggleOn = not Debugger.toggleOn
-end, true)
+	Debugger:ToggleOn(Debugger.toggleOn)
+	TriggerEvent('chat:addMessage', {
+		color = {255, 255, 0},
+		multiline = true,
+		args = {"Vehicle Debugger", Debugger.toggleOn and "Enabled" or "Disabled"}
+	})
+end, false)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,6 +1,6 @@
-author 'Jameslroll'
+author 'Kerminal'
 description 'Utility to edit the handling of vehicles and record speeds'
-version '1.0.0'
+version '1.1.0'
 
 fx_version 'cerulean'
 game 'gta5'

--- a/html/index.css
+++ b/html/index.css
@@ -51,7 +51,7 @@ button:active {
 }
 
 #content {
-	display: none;
+	display: block;
 	position: absolute;
 	left: 50vw;
 	top: 6vmin;

--- a/html/index.html
+++ b/html/index.html
@@ -9,9 +9,11 @@
 	<body>
 		<textarea id="clipboard"></textarea>
 		<div id="content">
-			<span>Top Speed: </span><span id="top-speed"></span><br>
-			<span>Top Acceleration: </span><span id="top-accel"></span><br>
-			<span>Top Deceleration: </span><span id="top-decel"></span><br>
+			<div id="statistics">
+				<span>Top Speed: </span><span id="top-speed"></span><br>
+				<span>Top Acceleration: </span><span id="top-accel"></span><br>
+				<span>Top Deceleration: </span><span id="top-decel"></span><br>
+			</div>
 			<div id="handling" style="display: none">
 				<button onclick="copyHandling()">Copy Handling</button>
 				<button onclick="post('resetStats')">Reset Stats</button>

--- a/html/index.js
+++ b/html/index.js
@@ -13,23 +13,17 @@ window.addEventListener("message", function (event) {
 function post(type, data) {
 	try {
 		fetch(`https://${GetParentResourceName()}/${type}`, {
-			method: "POST",
+			method: 'POST',
 			headers: {
-				"Content-Type": "application/json; charset=UTF-8",
+				'Content-Type': 'application/json; charset=UTF-8',
 			},
-			body: JSON.stringify(data),
-		});
+			body: JSON.stringify(data)
+		})
 	} catch { }
 }
 
-function toggle(value) {
-	document.querySelector("#content").style.display = value ? "block" : "none";
-}
-
 function setFocus(value) {
-	document.querySelector("#handling").style.display = value
-		? "block"
-		: "none";
+	document.querySelector("#handling").style.display = value ? "block" : "none";
 }
 
 function updateText(data) {
@@ -55,13 +49,17 @@ function copyText(text) {
 	element.value = undefined;
 }
 
+function toggle(value) {
+	document.querySelector("#content").style.display = value ? "block" : "none";
+}
+
 function copyHandling() {
-	post("copyHandling");
+	post("copyHandling")
 }
 
 function updateHandling(key, value) {
 	post("updateHandling", {
 		key: key,
 		value: value,
-	});
+	})
 }


### PR DESCRIPTION
## Changes

### Keybind Improvements
- Changed default keybind from Left Alt to Right Alt to avoid conflicts with third-eye and other UI systems that are now common.
- Made keybind configurable via `Config.Keybind` in `cl_config.lua`
- Added reference link to FiveM keybind documentation for easy customization

### Toggle System Improvements
- Debugger now enabled by default for better out-of-box experience
- Added `Config.EnabledByDefault` option to control initial state
- Fixed toggle functionality - properly hides all UI elements when disabled
- Added chat feedback when using `/vehdebug` command to show enabled/disabled state
- Fixed bug where `toggleOn` state wasn't being properly updated

### Permissions & Security
- Changed `/vehdebug` command from restricted to unrestricted by default
- Added security note in README about restricting command in live environments
- Documented how to modify command permissions for production use

### Documentation
- Updated README with new default keybind (Right Alt)
- Added instructions for customizing keybind via config
- Added security considerations for live server deployments
- Clarified that debugger works immediately without needing `/vehdebug` first

### UI Fixes
- Wrapped statistics in container for proper toggle behavior
- Added `toggle()` function to JavaScript to handle UI visibility
- Fixed UI now properly hides when debugger is toggled off

## Breaking Changes
None - all changes are backwards compatible with sensible defaults

## Configuration
Users can now customize in `cl_config.lua`:
- `Config.Keybind` - Set preferred keybind (default: "rmenu")
- `Config.EnabledByDefault` - Start enabled or disabled (default: true)